### PR TITLE
Bugfix regarding ErrorException

### DIFF
--- a/lib/DropboxClient.php
+++ b/lib/DropboxClient.php
@@ -83,7 +83,7 @@ class DropboxClient
                 $params = $this->uploadFileChunk($data, $params);
             }
 
-            return $this->uploadFileChunkCommit($params);
+            return $this->uploadFileChunkCommit($path, $params);
         }
 
         return $this->_uploadFile($path, $inStream, $numBytes);


### PR DESCRIPTION
  [ErrorException]  
  Missing argument 2 for DropboxClient::uploadFileChunkCommit(), called in /vendor/dropbox-factory/dropbox-factory/lib/DropboxClient.php on line 86 and defined
